### PR TITLE
Allow to use a config file to set default values

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -159,7 +159,7 @@ func CreateCluster(c *cli.Context) error {
 	 * --server-arg, -x
 	 * Add user-supplied arguments for the k3s server
 	 */
-	if c.IsSet("server-arg") || c.IsSet("x") {
+	if len(c.StringSlice("server-arg")) > 0 || len(c.StringSlice("x")) > 0 {
 		k3sServerArgs = append(k3sServerArgs, c.StringSlice("server-arg")...)
 	}
 
@@ -167,7 +167,7 @@ func CreateCluster(c *cli.Context) error {
 	 * --agent-arg
 	 * Add user-supplied arguments for the k3s agent
 	 */
-	if c.IsSet("agent-arg") {
+	if len(c.StringSlice("agent-arg")) > 0 {
 		if c.Int("workers") < 1 {
 			log.Warnln("--agent-arg supplied, but --workers is 0, so no agents will be created")
 		}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	// Configuration file loading
 	conf, confErr := loadConfig()
 	if confErr != nil {
-		panic(fmt.Sprintf("Error while loading configuration: %s", confErr))
+		log.Fatalf("Error while loading configuration: %s", confErr)
 	}
 
 	// App Details
@@ -387,7 +387,7 @@ func loadConfig() (Config, error) {
 			return Config{}, err
 		}
 
-		if err := yaml.Unmarshal(confFile, &conf); err != nil {
+		if err := yaml.UnmarshalStrict(confFile, &conf); err != nil {
 			return Config{}, err
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 
 	run "github.com/rancher/k3d/cli"
 	"github.com/rancher/k3d/version"
@@ -17,8 +20,26 @@ const defaultK3sClusterName string = "k3s-default"
 const defaultRegistryName = "registry.local"
 const defaultRegistryPort = 5000
 
+var (
+	defaultServerArgs = cli.StringSlice{}
+	defaultAgentArgs  = cli.StringSlice{}
+)
+
+// Config stores the loaded configuration file values
+type Config struct {
+	ClusterName string   `yaml:"cluster-name"`
+	ServerArgs  []string `yaml:"server-args"`
+	AgentArgs   []string `yaml:"agent-args"`
+	Workers     int      `yaml:"workers"`
+}
+
 // main represents the CLI application
 func main() {
+	// Configuration file loading
+	conf, confErr := loadConfig()
+	if confErr != nil {
+		panic(fmt.Sprintf("Error while loading configuration: %s", confErr))
+	}
 
 	// App Details
 	app := cli.NewApp()
@@ -42,7 +63,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "Set a name for the cluster",
 				},
 				cli.StringFlag{
@@ -65,7 +86,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "Set a name for the cluster",
 				},
 				cli.StringSliceFlag{
@@ -100,10 +121,12 @@ func main() {
 				cli.StringSliceFlag{
 					Name:  "server-arg, x",
 					Usage: "Pass an additional argument to k3s server (new flag per argument)",
+					Value: &defaultServerArgs,
 				},
 				cli.StringSliceFlag{
 					Name:  "agent-arg",
 					Usage: "Pass an additional argument to k3s agent (new flag per argument)",
+					Value: &defaultAgentArgs,
 				},
 				cli.StringSliceFlag{
 					Name:  "env, e",
@@ -115,7 +138,7 @@ func main() {
 				},
 				cli.IntFlag{
 					Name:  "workers, w",
-					Value: 0,
+					Value: conf.Workers,
 					Usage: "Specify how many worker nodes you want to spawn",
 				},
 				cli.BoolFlag{
@@ -158,7 +181,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "name, n",
 					Usage: "Name of the k3d cluster that you want to add a node to [only for node name if --k3s is set]",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 				},
 				cli.IntFlag{
 					Name:  "count, c",
@@ -208,7 +231,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "name of the cluster",
 				},
 				cli.BoolFlag{
@@ -229,7 +252,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "Name of the cluster",
 				},
 				cli.BoolFlag{
@@ -246,7 +269,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "Name of the cluster",
 				},
 				cli.BoolFlag{
@@ -270,7 +293,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "Name of the cluster",
 				},
 				cli.BoolFlag{
@@ -292,7 +315,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "name, n, cluster, c",
-					Value: defaultK3sClusterName,
+					Value: conf.ClusterName,
 					Usage: "Name of the cluster",
 				},
 				cli.BoolFlag{
@@ -344,4 +367,42 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func loadConfig() (Config, error) {
+	confDir, confDirerr := os.UserConfigDir()
+	if confDirerr != nil {
+		return Config{}, confDirerr
+	}
+
+	conf := Config{
+		ClusterName: defaultK3sClusterName,
+		Workers:     0,
+	}
+
+	confFilePath := filepath.Join(confDir, "k3d.yaml")
+	if _, err := os.Stat(confFilePath); err == nil {
+		confFile, err := ioutil.ReadFile(confFilePath)
+		if err != nil {
+			return Config{}, err
+		}
+
+		if err := yaml.Unmarshal(confFile, &conf); err != nil {
+			return Config{}, err
+		}
+	}
+
+	for _, serverArg := range conf.ServerArgs {
+		if err := defaultServerArgs.Set(serverArg); err != nil {
+			return Config{}, err
+		}
+	}
+
+	for _, agentArg := range conf.AgentArgs {
+		if err := defaultAgentArgs.Set(agentArg); err != nil {
+			return Config{}, err
+		}
+	}
+
+	return conf, nil
 }


### PR DESCRIPTION
Here is the first implementation of a configuration file.
In this version it will allow to define default values for some flags:
- The cluster's name
- The server's args
- The agent's args
- The number of workers

By default these values are the same than before to keep the old behavior.
The file is loaded from the user configuration directory (fetched with `os.UserConfigDir()` to ensure the cross-compatibility) and the file name must be `k3d.yaml`.

An example of a valid configuration file:

```yaml
cluster-name: dzr-k3s
server-args:
    - --no-deploy=traefik
    - --kube-apiserver-arg=runtime-config=apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true
agent-args:
    - --kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%
    - --kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%
workers: 1
```
According to this example the command `k3d create` creates a server `dzr-k3s` with the specified server arguments and one worker with the specified agent arguments.
The command `k3d delete` deletes the server `dzr-k3s`, the command `stop` stops it etc...