### PR TITLE
Register and run global and per-command hooks

### DIFF
--- a/main.go
+++ b/main.go
@@ -512,12 +512,11 @@ func runHooks(hooks [][]string, hookType, commandName string) error {
 		cmd := exec.Command(cmdName, args...)
 		log.Infof("Running %s-hook %s's command \"%s\"", hookType, commandName, cmd.String())
 		output, err := cmd.CombinedOutput()
+		log.Debugf("%s's %s-hook output:\n%s\n", commandName, hookType, output)
 
 		if err != nil {
 			return fmt.Errorf("Error in %s's %s-hook execution: %s", commandName, hookType, err)
 		}
-
-		log.Debugf("%s's %s-hook output:\n%s\n", commandName, hookType, output)
 	}
 
 	return nil


### PR DESCRIPTION
This PR allows to declare global and per-command hooks. Here is an example of such declaration in the YAML configuration file:

```yaml
cluster-name: dzr-k3s
server-args:
    - --no-deploy=traefik
    - --kube-apiserver-arg=runtime-config=apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true
agent-args:
    - --kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%
    - --kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%
workers: 1
hooks:
    global:
        pre:
            - ["echo", "First global pre hook"]
            - ["echo", "Second global pre hook"]
        post:
            - ["echo", "First global post hook"]
            - ["echo", "Second global post hook"]
    commands:
        create:
            pre:
                - ["echo", "First pre hook for create"]
                - ["echo", "Second pre hook for create"]
            post:
                - ["echo", "First post hook for create"]
                - ["echo", "Second post hook for create"]
        delete:
            pre:
                - ["echo", "First pre hook for delete"]
                - ["echo", "Second pre hook for delete"]
            post:
                - ["echo", "First post hook for delete"]
                - ["echo", "Second post hook for delete"]
```
Here is the output of the create command with this config:

```
$ k3d c
INFO[0000] Running pre-hook global's command "/usr/bin/echo First global pre hook" 
INFO[0000] Running pre-hook global's command "/usr/bin/echo Second global pre hook" 
INFO[0000] Running post-hook global's command "/usr/bin/echo First global post hook" 
INFO[0000] Running post-hook global's command "/usr/bin/echo Second global post hook" 
INFO[0000] Running pre-hook create's command "/usr/bin/echo First pre hook for create" 
INFO[0000] Running pre-hook create's command "/usr/bin/echo Second pre hook for create" 
INFO[0000] Created cluster network with ID 77c5a709ba557e70a023cbcfaea7275c20a7a9162b5129fe46c0cd8b47951739 
INFO[0000] Created docker volume  k3d-dzr-k3s-images    
INFO[0000] Creating cluster [dzr-k3s]                   
INFO[0000] Creating server using docker.io/rancher/k3s:latest... 
INFO[0000] Booting 1 workers for cluster dzr-k3s        
INFO[0001] Created worker with ID 22f815e9076d077b172e74c20ebd1a94862be4ef383c2cf4f6e689877ecb273e 
INFO[0001] SUCCESS: created cluster [dzr-k3s]           
INFO[0001] You can now use the cluster with:

export KUBECONFIG="$(k3d get-kubeconfig --name='dzr-k3s')"
kubectl cluster-info 
INFO[0001] Running post-hook create's command "/usr/bin/echo First post hook for create" 
INFO[0001] Running post-hook create's command "/usr/bin/echo Second post hook for create"
```

And in verbose mode to display the commands outputs:

```
$ k3d --verbose c
INFO[0000] Running pre-hook global's command "/usr/bin/echo First global pre hook" 
DEBU[0000] global's pre-hook output:
First global pre hook
 
INFO[0000] Running pre-hook global's command "/usr/bin/echo Second global pre hook" 
DEBU[0000] global's pre-hook output:
Second global pre hook
 
INFO[0000] Running post-hook global's command "/usr/bin/echo First global post hook" 
DEBU[0000] global's post-hook output:
First global post hook
 
INFO[0000] Running post-hook global's command "/usr/bin/echo Second global post hook" 
DEBU[0000] global's post-hook output:
Second global post hook
 
INFO[0000] Running pre-hook create's command "/usr/bin/echo First pre hook for create" 
DEBU[0000] create's pre-hook output:
First pre hook for create
 
INFO[0000] Running pre-hook create's command "/usr/bin/echo Second pre hook for create" 
DEBU[0000] create's pre-hook output:
Second pre hook for create
 
INFO[0000] Created cluster network with ID 7b265e1d8303324985db51fbde2f7496074e2a7eda0f79a4361cee85561f428d 
INFO[0000] Created docker volume  k3d-dzr-k3s-images    
INFO[0000] Creating cluster [dzr-k3s]                   
INFO[0000] Creating server using docker.io/rancher/k3s:latest... 
INFO[0000] Booting 1 workers for cluster dzr-k3s        
INFO[0000] Created worker with ID 0c20b24ca3d075e0d68927659391e2fc57c5fd9c0d5a9f7a3857f66c65aabc38 
INFO[0000] SUCCESS: created cluster [dzr-k3s]           
INFO[0000] You can now use the cluster with:

export KUBECONFIG="$(k3d get-kubeconfig --name='dzr-k3s')"
kubectl cluster-info 
INFO[0000] Running post-hook create's command "/usr/bin/echo First post hook for create" 
DEBU[0000] create's post-hook output:
First post hook for create
 
INFO[0000] Running post-hook create's command "/usr/bin/echo Second post hook for create" 
DEBU[0000] create's post-hook output:
Second post hook for create
```